### PR TITLE
Add the packaging metadata to build the branch-diff snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,20 @@
+name: branch-diff
+version: git
+summary: Compares 2 git branches without hassle.
+description: |
+    A tool to list print the commits on one git branch
+    that are not on another using loose comparison.
+grade: stable
+confinement: strict
+
+apps:
+  branch-diff:
+    command: bin/branch-diff
+    plugs: [network, home]
+
+parts:
+  branch-diff:
+    source: .
+    plugin: nodejs
+    stage-packages: [git]
+    build-packages: [zlib1g-dev]


### PR DESCRIPTION
This package will let you publish the latest branch-diff in the Ubuntu store, and from there reach many users on all the supported Ubuntu versions, and Linux distributions. You just have to go to https://build.snapcraft.io and enable the automated continuous delivery.

It was packaged and released to the store by @LaughingLove during [google code-in](https://codein.withgoogle.com/). So, when you try to register the name you will find that it is already taken. You just have to fill the form claiming that you are the upstream developer, and we will take care of the transfer.