### PR TITLE
Fix parsing of command line, so usage works

### DIFF
--- a/branch-diff.js
+++ b/branch-diff.js
@@ -148,7 +148,11 @@ function collect (repoPath, branch, startCommit, endRef) {
 module.exports = branchDiff
 
 if (require.main === module) {
-  let argv          = require('minimist')(process.argv.slice(2))
+  const config = {
+    boolean: ['version', 'group', 'patch-only', 'simple', 'filter-release',
+      'reverse'],
+  };
+  let argv          = require('minimist')(process.argv.slice(2), config)
     , branch1       = argv._[0]
     , branch2       = argv._[1]
     , format        = argv.format


### PR DESCRIPTION
Documented CLI of

   branch-diff --simple master fix-cli-flags

doesn't work, minimist assumes master is the value of `--simple` option,
it needs to be told about options that don't take values.
