### PR TITLE
feat: add plaintext option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ But the comparison isn't quite as strict, generally leading to a shorter list of
 * `--exclude-label`: Exclude any commits from the list that come from a GitHub pull request with the given label. Multiple `--exclude-label` options may be provided, they will also be split by `,`. e.g. `--exclude-label=semver-major,meta`.
 * `--require-label`: Only include commits in the list that come from a GitHub pull request with the given label. Multiple `--require-label` options may be provided, they will also be split by `,`. e.g. `--require-label=test,doc`.
 * `--patch-only`: An alias for `--exclude-label=semver-major,semver-minor`.
-* `--format`: Dictates what formatting the output will have. Possible options are: `simple`, `sha`. The default is to print markdown-formatted output.
+* `--format`: Dictates what formatting the output will have. Possible options are: `simple`, `plaintext`, and `sha`. The default is to print markdown-formatted output; `plaintext` also implies that commits will be grouped.
   - `simple`: Don't print full markdown output, good for console printing without the additional fluff.
   - `sha`: Print only the 10-character truncated commit shasums. Good for piping though additional tooling, such as `xargs git cherry-pick` for applying commits.
 * `--simple` or `-s`: An alias for `--format=simple`.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "bl": "~3.0.0",
-    "changelog-maker": "~2.3.0",
+    "changelog-maker": "~2.4.0",
     "commit-stream": "~1.1.0",
     "deep-equal": "~1.0.1",
     "gitexec": "~1.0.0",


### PR DESCRIPTION
Refs https://github.com/nodejs/changelog-maker/pull/80.

Leverages new `plaintext` changelog-maker functionality in `branch-diff` so that we can easily pull the notable changes into release commits without markdown cruft. I tested this to ensure working on `v13.x-staging`, with new sample output e.g:

```sh
build:
  * add --error-on-warn configure flag (Daniel Bevenius) https://github.com/nodejs/node/pull/32685
cluster:
  * fix error on worker disconnect/destroy (Santiago Gimeno) https://github.com/nodejs/node/pull/32793
crypto:
  * check DiffieHellman p and g params (Ben Noordhuis) https://github.com/nodejs/node/pull/32739
  * generator must be int32 in DiffieHellman() (Ben Noordhuis) https://github.com/nodejs/node/pull/32739
  * key size must be int32 in DiffieHellman() (Ben Noordhuis) https://github.com/nodejs/node/pull/32739
```

cc @MylesBorins @rvagg  