### PR TITLE
fix: require is not defined error

### DIFF
--- a/branch-diff.js
+++ b/branch-diff.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import fs from 'fs'
+import { createRequire } from 'module'
 import path from 'path'
 import process from 'process'
 import { pipeline as _pipeline } from 'stream'
@@ -15,6 +16,7 @@ import gitexec from 'gitexec'
 
 const pipeline = promisify(_pipeline)
 const pkgFile = path.join(process.cwd(), 'package.json')
+const require = createRequire(import.meta.url)
 const pkgData = fs.existsSync(pkgFile) ? require(pkgFile) : {}
 const pkgId = pkgtoId(pkgData)
 const refcmd = 'git rev-list --max-count=1 {{ref}}'


### PR DESCRIPTION
The `require()` function is not defined in ES module scope. Loading a
JSON file via `import` is behind `--experimental-json-modules` on LTS
versions of Node.js, so use `createRequire()` instead.

Refs: https://github.com/nodejs/branch-diff/pull/43

Fixes this error when there is a [`package.json` file in the current working directory](https://github.com/nodejs/branch-diff/blob/a28abaecfc15e9c7f2fcb8e9ed79c02494d2d894/branch-diff.js#L17-L18):
```console
$ nvm run 17 .
Running node v17.6.0 (npm v8.5.1)
file:///home/rlau/sandbox/github/branch-diff/branch-diff.js:18
const pkgData = fs.existsSync(pkgFile) ? require(pkgFile) : {}
                   ^

ReferenceError: require is not defined in ES module scope, you can use import instead
This file is being treated as an ES module because it has a '.js' file extension and '/home/rlau/sandbox/github/branch-diff/package.json' contains "type": "module". To treat it as a CommonJS script, rename it to use the '.cjs' file extension.
    at file:///home/rlau/sandbox/github/branch-diff/branch-diff.js:18:20
    at ModuleJob.run (node:internal/modules/esm/module_job:197:25)
    at async Promise.all (index 0)
    at async ESMLoader.import (node:internal/modules/esm/loader:341:24)
    at async loadESM (node:internal/process/esm_loader:88:5)
    at async handleMainPromise (node:internal/modules/run_main:61:12)

Node.js v17.6.0
```