### PR TITLE
add --user and --repo options

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ But the comparison isn't quite as strict, generally leading to a shorter list of
 * `--filter-release`: Exclude Node-style release commits from the list. e.g. `Working on v1.0.0` or `2015-10-21 Version 2.0.0`.
 * `--reverse`: Reverse the results, this is especially useful when piping output to `xargs`.
 * `--commit-url`:A URL template which will be used to generate commit URLs for a repository not hosted in GitHub. `{ref}` is the placeholder that will be replaced with the commit, i.e. `--commit-url=https://gitlab.com/myUser/myRepo/commit/{ref}`. `{ghUser}` and `{ghRepo}` are available if they can be derived from package.json (Gitlab and Bitbucket URLs should be understood in package.json).
+* `--user`: Override the auto-detected GitHub user/org derived from package.json
+* `--repo`: Override the auto-detected GitHub repository name derived from package.json
 
 ## License
 

--- a/branch-diff.js
+++ b/branch-diff.js
@@ -145,6 +145,14 @@ async function main () {
     requireLabels = requireLabels.concat(argv['require-label'])
   }
 
+  if (argv.user) {
+    ghId.user = argv.user
+  }
+
+  if (argv.repo) {
+    ghId.repo = argv.repo
+  }
+
   const options = {
     group,
     excludeLabels,


### PR DESCRIPTION
Allows for overriding the user and repo variables when auto-detection fails.