### PR TITLE
restore label filtering

### DIFF
--- a/branch-diff.js
+++ b/branch-diff.js
@@ -12,6 +12,7 @@ import pkgtoId from 'pkg-to-id'
 import minimist from 'minimist'
 import { isReleaseCommit } from 'changelog-maker/groups'
 import { processCommits } from 'changelog-maker/process-commits'
+import { collectCommitLabels } from 'changelog-maker/collect-commit-labels'
 import gitexec from 'gitexec'
 
 const pipeline = promisify(_pipeline)
@@ -73,6 +74,8 @@ async function diffCollected (options, branchCommits) {
   }
 
   let list = branchCommits[1].filter((commit) => !isInList(commit))
+
+  await collectCommitLabels(list)
 
   if (options.excludeLabels.length > 0) {
     list = list.filter((commit) => {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "Rod <rod@vagg.org> (http://r.va.gg/)",
   "license": "MIT",
   "dependencies": {
-    "changelog-maker": "^3.0.0",
+    "changelog-maker": "^3.1.0",
     "commit-stream": "^1.1.0",
     "gitexec": "^2.0.1",
     "minimist": "^1.2.5",


### PR DESCRIPTION
As far as I can tell, this fixes #45.

This depends on https://github.com/nodejs/changelog-maker/pull/127

The labels get cached, so it's fine that we call it once here and again inside processCommits.