### PR TITLE
deps: update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,12 +15,12 @@
   "author": "Rod <rod@vagg.org> (http://r.va.gg/)",
   "license": "MIT",
   "dependencies": {
-    "changelog-maker": "^3.1.0",
+    "changelog-maker": "^3.2.2",
     "commit-stream": "^2.0.1",
     "gitexec": "^2.0.1",
-    "minimist": "^1.2.5",
+    "minimist": "^1.2.8",
     "pkg-to-id": "^0.0.3",
-    "split2": "^4.1.0"
+    "split2": "^4.2.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "Rod <rod@vagg.org> (http://r.va.gg/)",
   "license": "MIT",
   "dependencies": {
-    "changelog-maker": "^3.2.2",
+    "changelog-maker": "^3.2.3",
     "commit-stream": "^2.0.1",
     "gitexec": "^2.0.1",
     "minimist": "^1.2.8",


### PR DESCRIPTION
Update dependencies to their latest versions, this is to mainly update the `changelog-maker` dependency.

Refs: https://github.com/nodejs/branch-diff/pull/54#issuecomment-1498746897