### PR TITLE
chore: update repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/rvagg/branch-diff.git"
+    "url": "https://github.com/nodejs/branch-diff.git"
   },
   "preferGlobal": true,
   "devDependencies": {


### PR DESCRIPTION
Update `repository.url` in package.json to avoid a redirect for tooling that uses it.

---

Hopefully this fixes the Release job in the Test & Maybe Release workflow which is [currently failing](https://github.com/nodejs/branch-diff/actions/runs/7815331643/job/21318530066#step:7:108) with
```console
[1:14:43 PM] [semantic-release] › ✘  An error occurred while running semantic-release: RequestError [HttpError]: Request body length does not match content-length header
```

Refs: https://github.com/semantic-release/github/issues/746