### PR TITLE
feat: add limit-commits option

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ But the comparison isn't quite as strict, generally leading to a shorter list of
 * `--commit-url`:A URL template which will be used to generate commit URLs for a repository not hosted in GitHub. `{ref}` is the placeholder that will be replaced with the commit, i.e. `--commit-url=https://gitlab.com/myUser/myRepo/commit/{ref}`. `{ghUser}` and `{ghRepo}` are available if they can be derived from package.json (Gitlab and Bitbucket URLs should be understood in package.json).
 * `--user`: Override the auto-detected GitHub user/org derived from package.json
 * `--repo`: Override the auto-detected GitHub repository name derived from package.json
+* `--limit-commits`: `number` Limits the number of commits for branch-diff to work with, e.g: `--limit-commits=500`. Note that this limit is set prior to applying all filters, this number does not represent the number of resulting commits.
+* `--skip-commits`: `number` Defines an amount of commits to be skipped from the initial difference list built between `base-branch` and `comparison-branch`, e.g: `--skip-commits=400`.
+
+### Reducing the amount of commits to avoid hitting GitHub rate limits
+
+Using the `limit-commits` and `skip-commits` options allow users to reduce the amount of commits that branch-diff will work with in order to avoid hitting GitHub API rate limits.
 
 ## License
 

--- a/branch-diff.js
+++ b/branch-diff.js
@@ -75,6 +75,16 @@ async function diffCollected (options, branchCommits) {
 
   let list = branchCommits[1].filter((commit) => !isInList(commit))
 
+  if (options.limitCommits > 0) {
+    list = list.slice(-options.limitCommits)
+  }
+
+  // TODO: finish clean up the transition to skipCommits
+  // TODO: branch-diff should error with exit code on GitHub API error
+  if (options.skipCommits > 0) {
+    list = list.slice(options.skipCommits)
+  }
+
   await collectCommitLabels(list)
 
   if (options.excludeLabels.length > 0) {
@@ -125,6 +135,8 @@ async function main () {
   const endRef = argv['end-ref']
   let excludeLabels = []
   let requireLabels = []
+  let limitCommits;
+  let skipCommits;
 
   if (argv.version || argv.v) {
     return console.log(`v ${require('./package.json').version}`)
@@ -148,6 +160,14 @@ async function main () {
     requireLabels = requireLabels.concat(argv['require-label'])
   }
 
+  if (argv['limit-commits']) {
+    limitCommits = parseInt(argv['limit-commits'], 10);
+  }
+
+  if (argv['skip-commits']) {
+    skipCommits = parseInt(argv['skip-commits'], 10);
+  }
+
   if (argv.user) {
     ghId.user = argv.user
   }
@@ -160,6 +180,8 @@ async function main () {
     group,
     excludeLabels,
     requireLabels,
+    limitCommits,
+    skipCommits,
     endRef
   }
 


### PR DESCRIPTION
Last time I had to fight GitHub API secondary rate limits for a very long-lived LTS release I ended up writing this (based on knowledge shared from @BethGriggs) to help me unblock retrieving a list of commits from branch-diff.

Although it might be functional, the current API here is very clunky and requires the user to find out how many commits are already ignored in order to provide that value to `skip-commits` and from a combination of `skip-commits` and `limit-commits` hopefully cut out a limited enough series of commit that will not trigger GitHub API limits.

Opening this as a draft so that we can discuss better alternatives.